### PR TITLE
support select field with special character

### DIFF
--- a/query_builder.go
+++ b/query_builder.go
@@ -211,14 +211,13 @@ func (q *Query) buildFields() string {
 		return ""
 	}
 
-	tmpl := `%s`
 	fields := make([]string, len(q.fields))
 
 	for i := range fields {
 		if functionMatcher.MatchString(q.fields[i]) {
 			fields[i] = q.fields[i]
 		} else {
-			fields[i] = fmt.Sprintf(tmpl, q.fields[i])
+			fields[i] = fmt.Sprintf("\"%s\"", q.fields[i])
 		}
 	}
 

--- a/query_builder_test.go
+++ b/query_builder_test.go
@@ -12,8 +12,8 @@ func assert(t *testing.T, q interface{}, expected interface{}) {
 }
 
 func TestClean(t *testing.T) {
-	builder := New()
 	expected := ""
+	builder := New()
 	builder.
 		Select("temperature", "humidity").
 		From("measurement").
@@ -25,13 +25,23 @@ func TestClean(t *testing.T) {
 }
 
 func TestSelect(t *testing.T) {
+	expected := `SELECT "temperature","humidity" FROM "measurement"`
 	builder := New()
-	expected := `SELECT temperature,humidity FROM "measurement"`
 	q := builder.
 		Select("temperature", "humidity").
 		From("measurement").
 		Build()
 
+	assert(t, q, expected)
+}
+
+func TestSelectFieldWithSpecialCharacter(t *testing.T) {
+	expected := `SELECT "temperature-with-hyphen" FROM "measurement"`
+	builder := New()
+	q := builder.
+		Select("temperature-with-hyphen").
+		From("measurement").
+		Build()
 	assert(t, q, expected)
 }
 
@@ -47,7 +57,7 @@ func TestSelectFunction(t *testing.T) {
 }
 
 func TestWhere(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE "time" < '2018-11-02T09:35:25Z'`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "time" < '2018-11-02T09:35:25Z'`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -58,7 +68,7 @@ func TestWhere(t *testing.T) {
 }
 
 func TestAnd(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' AND "time" < '2018-11-02T09:35:25Z'`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' AND "time" < '2018-11-02T09:35:25Z'`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -71,7 +81,7 @@ func TestAnd(t *testing.T) {
 }
 
 func TestOr(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' OR "time" < '2018-11-02T09:35:25Z'`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' OR "time" < '2018-11-02T09:35:25Z'`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -84,7 +94,7 @@ func TestOr(t *testing.T) {
 }
 
 func TestWhereAndOr(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' AND "time" < '2018-11-02T09:35:25Z' OR "tag" = 't'`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' AND "time" < '2018-11-02T09:35:25Z' OR "tag" = 't'`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -98,7 +108,7 @@ func TestWhereAndOr(t *testing.T) {
 }
 
 func TestGroupBy(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" GROUP BY time(10m)`
+	expected := `SELECT "temperature","humidity" FROM "measurement" GROUP BY time(10m)`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -110,7 +120,7 @@ func TestGroupBy(t *testing.T) {
 }
 
 func TestFill(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" FILL(1)`
+	expected := `SELECT "temperature","humidity" FROM "measurement" FILL(1)`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -122,7 +132,7 @@ func TestFill(t *testing.T) {
 }
 
 func TestAscOrder(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" ORDER BY time ASC`
+	expected := `SELECT "temperature","humidity" FROM "measurement" ORDER BY time ASC`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -134,7 +144,7 @@ func TestAscOrder(t *testing.T) {
 }
 
 func TestDescOrder(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" ORDER BY time DESC`
+	expected := `SELECT "temperature","humidity" FROM "measurement" ORDER BY time DESC`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -146,7 +156,7 @@ func TestDescOrder(t *testing.T) {
 }
 
 func TestLimitOffset(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" LIMIT 10 OFFSET 5`
+	expected := `SELECT "temperature","humidity" FROM "measurement" LIMIT 10 OFFSET 5`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -159,7 +169,7 @@ func TestLimitOffset(t *testing.T) {
 }
 
 func TestBracketsWhere(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE ("time" > '2018-11-01T06:33:57.503Z' AND "time" < '2018-11-02T09:35:25Z') OR "tag" = 't'`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE ("time" > '2018-11-01T06:33:57.503Z' AND "time" < '2018-11-02T09:35:25Z') OR "tag" = 't'`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -176,7 +186,7 @@ func TestBracketsWhere(t *testing.T) {
 }
 
 func TestBracketsAndCriteria(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' AND ("time" < '2018-11-02T09:35:25Z' OR "tag" = 't')`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' AND ("time" < '2018-11-02T09:35:25Z' OR "tag" = 't')`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -193,7 +203,7 @@ func TestBracketsAndCriteria(t *testing.T) {
 }
 
 func TestBracketsOrCriteria(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' OR ("time" < '2018-11-02T09:35:25Z' OR "tag" = 't')`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "time" > '2018-11-01T06:33:57.503Z' OR ("time" < '2018-11-02T09:35:25Z' OR "tag" = 't')`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -210,7 +220,7 @@ func TestBracketsOrCriteria(t *testing.T) {
 }
 
 func TestWhereTypeSqlQuote(t *testing.T) {
-	expected := `SELECT temperature,humidity FROM "measurement" WHERE "temperature" > 20 OR "humidity" < 10.101`
+	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "temperature" > 20 OR "humidity" < 10.101`
 	builder := New()
 	q := builder.
 		Select("temperature", "humidity").
@@ -220,7 +230,7 @@ func TestWhereTypeSqlQuote(t *testing.T) {
 		Build()
 	assert(t, q, expected)
 
-	expected = `SELECT temperature FROM "measurement" WHERE "hot" = true`
+	expected = `SELECT "temperature" FROM "measurement" WHERE "hot" = true`
 	q = builder.
 		Clean().
 		Select("temperature").


### PR DESCRIPTION
Select fields with special character (e.g. x-y-z) will be transformed unexpectedly in influx:

```go
builder.Select("x-y-z") 
// => SELECT x-y-z (output query string) 
// => SELECT x - y - z (output query string in influx)
```

This PR adds double quotes around selected fields in output query, above example will now become:

```go
builder.Select("x-y-z") 
// => SELECT "x-y-z" (output query string) 
// => SELECT "x-y-z" (output query string in influx)
```

and this works fine in influx.