### PR TITLE
fix support of unquoted value on time criteria

### DIFF
--- a/query_builder.go
+++ b/query_builder.go
@@ -317,7 +317,7 @@ func (q *Query) Build() string {
 }
 
 var functionMatcher = regexp.MustCompile(`.+\(.+\)$`)
-var mathMatcher = regexp.MustCompile(`^(.+?)([+\-\/*])(\s+)?(\d+)(\.\d+)?$`)
+var mathMatcher = regexp.MustCompile(`^(.+?)(([+\-\/*])(\s+)?(\d+)(\.\d+)?)+$`)
 
 func (q *Query) buildFields() string {
 	if q.fields == nil {

--- a/query_builder.go
+++ b/query_builder.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+var validUnquotedTimeRegexp = regexp.MustCompile(`^\d+(ns|u|ms|s|m|h|d|w)?$`)
+
 // Duration Duration interface
 type Duration interface {
 	Nanoseconds(uint) Duration
@@ -511,6 +513,10 @@ func getCriteriaTemplate(tag Tag) string {
 	case bool:
 		return fmt.Sprintf(`"%s" %s %t`, tag.key, tag.op, tag.value)
 	default:
+		if tag.key == "time" && validUnquotedTimeRegexp.MatchString(tag.value.(string)) {
+			// 'time' key accepts non-quoted string value (eg: 1535313431000ns)
+			return fmt.Sprintf(`%s %s %s`, tag.key, tag.op, tag.value)
+		}
 		return fmt.Sprintf(`"%s" %s '%s'`, tag.key, tag.op, tag.value)
 	}
 }

--- a/query_builder.go
+++ b/query_builder.go
@@ -317,7 +317,7 @@ func (q *Query) Build() string {
 }
 
 var functionMatcher = regexp.MustCompile(`.+\(.+\)$`)
-var mathMatcher = regexp.MustCompile(`^(.+?)(([+\-\/*])(\s+)?(\d+)(\.\d+)?)+$`)
+var mathMatcher = regexp.MustCompile(`^(.+?)((\s?)([\-\+\/\*])(\s?)(-?\d+)(\.\d+)?)+`)
 
 func (q *Query) buildFields() string {
 	if q.fields == nil {

--- a/query_builder.go
+++ b/query_builder.go
@@ -317,6 +317,7 @@ func (q *Query) Build() string {
 }
 
 var functionMatcher = regexp.MustCompile(`.+\(.+\)$`)
+var mathMatcher = regexp.MustCompile(`^(.+?)([+\-\/*])(\s+)?(\d+)(\.\d+)?$`)
 
 func (q *Query) buildFields() string {
 	if q.fields == nil {
@@ -340,6 +341,8 @@ func (q *Query) buildFields() string {
 
 		if functionMatcher.MatchString(selectField) {
 			fields[i] = selectField
+        } else if mathMatcher.MatchString(selectField) {
+            fields[i] = selectField
 		} else {
 			fields[i] = fmt.Sprintf("\"%s\"", selectField)
 		}

--- a/query_builder.go
+++ b/query_builder.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+var validUnquotedTimeRegexp = regexp.MustCompile(`^\d+(ns|u|ms|s|m|h|d|w)?$`)
+
 // Duration Duration interface
 type Duration interface {
 	Nanoseconds(uint) Duration
@@ -511,6 +513,10 @@ func getCriteriaTemplate(tag Tag) string {
 	case bool:
 		return fmt.Sprintf(`"%s" %s %t`, tag.key, tag.op, tag.value)
 	default:
+		if tag.key == "time" && validUnquotedTimeRegexp.MatchString(tag.value) {
+			// 'time' key accepts non-quoted string value (eg: 1535313431000ns)
+			return fmt.Sprintf(`%s %s %s`, tag.key, tag.op, tag.value)
+		}
 		return fmt.Sprintf(`"%s" %s '%s'`, tag.key, tag.op, tag.value)
 	}
 }

--- a/query_builder.go
+++ b/query_builder.go
@@ -317,7 +317,7 @@ func (q *Query) Build() string {
 }
 
 var functionMatcher = regexp.MustCompile(`.+\(.+\)$`)
-var mathMatcher = regexp.MustCompile(`^(.+?)((\s?)([\-\+\/\*])(\s?)(-?\d+)(\.\d+)?)+`)
+var mathMatcher = regexp.MustCompile(`^(.+?)((\s*)([\-\+\/\*])(\s*)(-?\d+)(\.\d+)?)+`)
 
 func (q *Query) buildFields() string {
 	if q.fields == nil {


### PR DESCRIPTION
influxql permits to set an unquoted string for a timestamp : 
time >= 12ms

this PR adds support to this case