### PR TITLE
From retention policy and group by multiple tags

### DIFF
--- a/query_builder_test.go
+++ b/query_builder_test.go
@@ -279,6 +279,36 @@ func TestGroupByTag(t *testing.T) {
 	assert(t, q, expected)
 }
 
+func TestGroupByTags(t *testing.T) {
+	expected := `SELECT "temperature","humidity" FROM "measurement" GROUP BY sensorId,location`
+	builder := New()
+	q := builder.
+		Select("temperature", "humidity").
+		From("measurement").
+		GroupByTag("sensorId", "location").
+		Build()
+
+	assert(t, q, expected)
+
+	q = New().
+		Select("temperature", "humidity").
+		From("measurement").
+		GroupByTag("sensorId").
+		GroupByTag("location").
+		Build()
+
+	assert(t, q, expected)
+
+	q = New().
+		Select("temperature", "humidity").
+		From("measurement").
+		GroupByTime(NewDuration().Minute(5)).
+		GroupByTag("sensorId", "location").
+		Build()
+	assert(t, q,
+		`SELECT "temperature","humidity" FROM "measurement" GROUP BY time(5m),sensorId,location`)
+}
+
 func TestFill(t *testing.T) {
 	expected := `SELECT "temperature","humidity" FROM "measurement" FILL(1)`
 	builder := New()

--- a/query_builder_test.go
+++ b/query_builder_test.go
@@ -89,6 +89,17 @@ func TestSelectFunctionAs(t *testing.T) {
 	assert(t, q, expected)
 }
 
+func TestFrom(t *testing.T) {
+	expected := `SELECT "temperature","humidity" FROM rp_1h."measurement"`
+	builder := New()
+	q := builder.
+		Select("temperature", "humidity").
+		FromRP("rp_1h", "measurement").
+		Build()
+
+	assert(t, q, expected)
+}
+
 func TestWhere(t *testing.T) {
 	expected := `SELECT "temperature","humidity" FROM "measurement" WHERE "time" < '2018-11-02T09:35:25Z'`
 	builder := New()


### PR DESCRIPTION
* Allow to query from rp qualified measurement, such as `select * from rp_1d."my.metrics"`
* Allow to group by multiple tags, along with time interval, such as `group by time(5m),sensorId,location`

Fix #11 